### PR TITLE
fixed bug where pressing shuffle then starting routine would cause a …

### DIFF
--- a/app/src/main/java/com/example/musictoned/routine/RoutineScreen.kt
+++ b/app/src/main/java/com/example/musictoned/routine/RoutineScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
@@ -41,7 +40,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -54,8 +52,6 @@ import com.example.musictoned.util.supportWideScreen
 import com.example.musictoned.workoutcreation.AllWorkouts
 import com.example.musictoned.workoutcreation.Workout
 import com.example.musictoned.workoutcreation.WorkoutExercise
-import com.example.musictoned.spotify.SpotifyConnect
-import com.example.musictoned.workoutcreation.AllWorkouts.saveWorkout
 
 /**
  * Influenced by composable UI example provided by Android

--- a/app/src/main/java/com/example/musictoned/routine/RoutineScreen.kt
+++ b/app/src/main/java/com/example/musictoned/routine/RoutineScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
@@ -54,6 +55,7 @@ import com.example.musictoned.workoutcreation.AllWorkouts
 import com.example.musictoned.workoutcreation.Workout
 import com.example.musictoned.workoutcreation.WorkoutExercise
 import com.example.musictoned.spotify.SpotifyConnect
+import com.example.musictoned.workoutcreation.AllWorkouts.saveWorkout
 
 /**
  * Influenced by composable UI example provided by Android
@@ -98,7 +100,7 @@ fun RoutineScreen(
                 BottomBar( modifier = Modifier.padding( top = 5.dp ),
                     start = {
                         if (routineID != null) {
-                            onNavigateToPlayer(routineID)
+                              onNavigateToPlayer(workout.hashCode())
                         }
                     }
                 )
@@ -301,7 +303,6 @@ private fun Exercise(
                                 .fillMaxHeight()
                                 .height(IntrinsicSize.Min),
                         ){
-
                             Image(
                                 painter = painterResource(id = R.drawable.shuffle),
                                 modifier = modifier
@@ -313,7 +314,6 @@ private fun Exercise(
                                                 exercise.setSongByBPM(exercise.getBpmMode())
                                                 //exercise.setSong("Comfortably Numb", "ID")
                                                 songName = exercise.getSong()
-                                                Log.d("SHUFFLE:", exercise.getSong())
                                                },
                                 contentDescription = "Shuffle button",
                                 contentScale = ContentScale.FillHeight,


### PR DESCRIPTION
…crash


THIS WAS LITERALLY A ONE LINE BUG FIX, MY BRAIN IS SO FRIED AHHHHHHHHHHHHH!

What was happening was the routineScreen wasn't expecting any changes to the routine to occur on that page, so it passed its provided routineID onto the player. But, when we press shuffle, it changes the routine (by changing a song associated with an exercise), ie changes the hashcode, so, when we passed the provided routineID, it just didn't exist anymore. We needed to pass the workout hashcode to the player.